### PR TITLE
Update EventCreateEdit.java

### DIFF
--- a/CMPUT301W24T33/app/src/main/java/com/example/cmput301w24t33/organizerFragments/EventCreateEdit.java
+++ b/CMPUT301W24T33/app/src/main/java/com/example/cmput301w24t33/organizerFragments/EventCreateEdit.java
@@ -63,8 +63,10 @@ public class EventCreateEdit extends Fragment implements EventChooseQR.ChooseQRF
     private String qrcode = null;
 
     private FirebaseStorage storage;
-    private String imageRef;
-    private String imageUrl;
+    private String eventImageRef;
+    private String eventImageUrl;
+    // set to false if entering image select from gallery activity, turns true if upload or exit
+    private boolean doneImageUpload = true;
 
     private ActivityResultLauncher<Intent> launcher = registerForActivityResult(
             new ActivityResultContracts.StartActivityForResult(),
@@ -72,6 +74,7 @@ public class EventCreateEdit extends Fragment implements EventChooseQR.ChooseQRF
                 if(result.getResultCode() == Activity.RESULT_OK
                         && result.getData() != null) {
                     storage = FirebaseStorage.getInstance();
+                    doneImageUpload = false;
                     Uri photoUri = result.getData().getData();
                     Log.d("returned url",photoUri.toString());
 
@@ -81,8 +84,9 @@ public class EventCreateEdit extends Fragment implements EventChooseQR.ChooseQRF
                             // Handle the success case here
                             // For example, store the result.first as the image URL and result.second as the image name
                             Log.d("Upload Success", "URL: " + result.first + ", Name: " + result.second);
-                            imageRef = result.second;
-                            imageUrl = result.first;
+                            eventImageRef = result.second;
+                            eventImageUrl = result.first;
+                            doneImageUpload = true;
                         }
                         @Override
                         public void onFailure(Exception e) {
@@ -90,6 +94,10 @@ public class EventCreateEdit extends Fragment implements EventChooseQR.ChooseQRF
                             Log.d("Upload Failure", e.toString());
                         }
                     });
+                }
+                // result code shows activity cancelled, happens when back button pressed
+                else if (result.getResultCode() == Activity.RESULT_CANCELED) {
+                    doneImageUpload = true;
                 }
             }
     );
@@ -218,12 +226,15 @@ public class EventCreateEdit extends Fragment implements EventChooseQR.ChooseQRF
             return;
         }
  */
-
-        // DATABASE CODE GOES HERE
-        saveEvent();
-
-        Snackbar.make(binding.getRoot(), "Event Created", Snackbar.LENGTH_SHORT).show();
-        getParentFragmentManager().popBackStack();
+        if (doneImageUpload) {
+            // DATABASE CODE GOES HERE
+            saveEvent();
+            Snackbar.make(binding.getRoot(), "Event Created", Snackbar.LENGTH_SHORT).show();
+            getParentFragmentManager().popBackStack();
+        }
+        else{
+            Snackbar.make(binding.getRoot(), "Uploading Poster", Snackbar.LENGTH_SHORT).show();
+        }
     }
 
     /**
@@ -263,6 +274,9 @@ public class EventCreateEdit extends Fragment implements EventChooseQR.ChooseQRF
         event.setEndDate(Objects.requireNonNull(binding.endDateEditText.getText()).toString().trim());
         event.setEndTime(Objects.requireNonNull(binding.endTimeEditText.getText()).toString().trim());
         event.setGeoTracking(binding.geoTrackingSwitch.isChecked());
+        Log.d("setURL","a"+eventImageUrl);
+        event.setImageUrl(eventImageUrl);
+        event.setImageRef(eventImageRef);
         //event.setMaxOccupancy(Integer.parseInt(Objects.requireNonNull(binding.maxAttendeesEditText.getText()).toString().trim()));
 
 


### PR DESCRIPTION
Events can now have posters uploaded. A field in events in db will hold poster image url and imageref for image deletion. Added logic to wait until either poster is uploaded or gallery activity is cancelled to create/edit event.